### PR TITLE
Exit serial monitor on unexpected errors

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -194,7 +194,12 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         let x = br.read_u8();
         match x {
             Ok(x) => print!("{}", x as char),
-            Err(_) => {}
+            Err(e) => {
+                if e.kind() != std::io::ErrorKind::TimedOut {
+                    println!("{:?}", e);
+                    break;
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Previously, blash would busy-loop if the serial adapter was unplugged
while the serial monitor was running.